### PR TITLE
Ability to use this passport with multi-threads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "0.10"

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -1,0 +1,31 @@
+# Load all required libraries.
+gulp = require 'gulp'
+gutil = require 'gulp-util'
+coffee = require 'gulp-coffee'
+istanbul = require 'gulp-istanbul'
+mocha = require 'gulp-mocha'
+plumber = require 'gulp-plumber'
+
+gulp.on 'err', (e) ->
+  gutil.beep()
+  gutil.log e.err.stack
+
+gulp.task 'coffee', ->
+  gulp.src './src/**/*.coffee'
+    .pipe plumber() # Pevent pipe breaking caused by errors from gulp plugins
+    .pipe coffee({bare: true})
+    .pipe gulp.dest './lib/passport-shopify/'
+
+gulp.task 'test', ['coffee'], ->
+  gulp.src ['lib/passport-shopify/**/*.js']
+    .pipe(istanbul()) # Covering files
+    .pipe(istanbul.hookRequire()) # Overwrite require so it returns the covered files
+    .on 'finish', ->
+      gulp.src(['test/**/*.spec.coffee'])
+        .pipe mocha reporter: 'spec', compilers: 'coffee:coffee-script'
+        .pipe istanbul.writeReports() # Creating the reports after tests run
+
+gulp.task 'watch', ->
+  gulp.watch './src/**/*.coffee', ['coffee']
+
+gulp.task 'default', ['coffee']

--- a/lib/passport-shopify/index.js
+++ b/lib/passport-shopify/index.js
@@ -1,15 +1,21 @@
-/**
+
+/*
  * Module dependencies.
  */
-var Strategy = require('./strategy');
+var Strategy;
+
+Strategy = require('./strategy');
 
 
-/**
+/*
  * Framework version.
  */
+
 require('pkginfo')(module, 'version');
 
-/**
+
+/*
  * Expose constructors.
  */
+
 exports.Strategy = Strategy;

--- a/lib/passport-shopify/strategy.js
+++ b/lib/passport-shopify/strategy.js
@@ -21,14 +21,16 @@ Strategy = (function(superClass) {
   extend(Strategy, superClass);
 
   function Strategy(options, verify) {
+    var shopName;
     options = options || {};
     if (options.shop == null) {
       options.shop = 'example';
     }
+    shopName = this.normalizeShopName(options.shop);
     _.defaults(options, {
-      authorizationURL: "https://" + options.shop + ".myshopify.com/admin/oauth/authorize",
-      tokenURL: "https://" + options.shop + ".myshopify.com/admin/oauth/access_token",
-      profileURL: "https://" + options.shop + ".myshopify.com/admin/shop.json",
+      authorizationURL: "https://" + shopName + "/admin/oauth/authorize",
+      tokenURL: "https://" + shopName + "/admin/oauth/access_token",
+      profileURL: "https://" + shopName + "/admin/shop.json",
       userAgent: 'passport-shopify',
       customHeaders: {},
       scopeSeparator: ','
@@ -76,12 +78,24 @@ Strategy = (function(superClass) {
   };
 
   Strategy.prototype.authenticate = function(req, options) {
-    _.defaults(options, {
-      authorizationURL: "https://" + options.shop + ".myshopify.com/admin/oauth/authorize",
-      tokenURL: "https://" + options.shop + ".myshopify.com/admin/oauth/access_token",
-      profileURL: "https://" + options.shop + ".myshopify.com/admin/shop.json"
-    });
+    var shopName;
+    if (options.shop != null) {
+      shopName = this.normalizeShopName(options.shop);
+      _.defaults(options, {
+        authorizationURL: "https://" + shopName + "/admin/oauth/authorize",
+        tokenURL: "https://" + shopName + "/admin/oauth/access_token",
+        profileURL: "https://" + shopName + "/admin/shop.json"
+      });
+    }
     return Strategy.__super__.authenticate.call(this, req, options);
+  };
+
+  Strategy.prototype.normalizeShopName = function(shop) {
+    if (shop.match(/^[a-z0-9-_]+$/i)) {
+      return shop + ".myshopify.com";
+    } else {
+      return shop;
+    }
   };
 
   return Strategy;

--- a/lib/passport-shopify/strategy.js
+++ b/lib/passport-shopify/strategy.js
@@ -2,9 +2,9 @@
 /*
  * Module dependencies.
  */
-var InternalOAuthError, OAuth2Strategy, Strategy, _, util;
-
-util = require('util');
+var InternalOAuthError, OAuth2Strategy, Strategy, _,
+  extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
+  hasProp = {}.hasOwnProperty;
 
 OAuth2Strategy = require('passport-oauth').OAuth2Strategy;
 
@@ -14,82 +14,79 @@ _ = require('lodash');
 
 
 /*
- * Inherit from `OAuth2Strategy`.
+ * Inherit `Strategy` from `OAuth2Strategy`.
  */
 
-Strategy = function(options, verify) {
-  options = options || {};
-  if (typeof options.shop === 'undefined') {
-    throw new TypeError('shop option is required!');
+Strategy = (function(superClass) {
+  extend(Strategy, superClass);
+
+  function Strategy(options, verify) {
+    options = options || {};
+    if (options.shop == null) {
+      options.shop = 'example';
+    }
+    _.defaults(options, {
+      authorizationURL: "https://" + options.shop + ".myshopify.com/admin/oauth/authorize",
+      tokenURL: "https://" + options.shop + ".myshopify.com/admin/oauth/access_token",
+      profileURL: "https://" + options.shop + ".myshopify.com/admin/shop.json",
+      userAgent: 'passport-shopify',
+      customHeaders: {},
+      scopeSeparator: ','
+    });
+    _.defaults(options.customHeaders, {
+      'User-Agent': options.userAgent
+    });
+    Strategy.__super__.constructor.call(this, options, verify);
+    this.name = 'shopify';
+    this._profileURL = options.profileURL;
+    this._clientID = options.clientID;
+    this._clientSecret = options.clientID;
+    this._callbackURL = options.callbackURL;
+    return;
   }
-  _.defaults(options, {
-    authorizationURL: 'https://' + options.shop + '.myshopify.com/admin/oauth/authorize',
-    tokenURL: 'https://' + options.shop + '.myshopify.com/admin/oauth/access_token',
-    profileURL: 'https://' + options.shop + '.myshopify.com/admin/shop.json',
-    userAgent: 'passport-shopify',
-    customHeaders: {},
-    scopeSeparator: ','
-  });
-  _.defaults(options.customHeaders, {
-    'User-Agent': options.userAgent
-  });
-  OAuth2Strategy.call(this, options, verify);
-  this.name = 'shopify';
-  this._profileURL = options.profileURL;
-  this._clientID = options.clientID;
-  this._clientSecret = options.clientID;
-  this._callbackURL = options.callbackURL;
-};
 
-util.inherits(Strategy, OAuth2Strategy);
+  Strategy.prototype.userProfile = function(accessToken, done) {
+    this._oauth2.get(this._options.profileURL, accessToken, function(err, body, res) {
+      var e, error, json, profile;
+      if (err) {
+        return done(new InternalOAuthError('Failed to fetch user profile', err));
+      }
+      try {
+        json = JSON.parse(body);
+        profile = {
+          provider: 'shopify'
+        };
+        profile.id = json.shop.id;
+        profile.displayName = json.shop.shop_owner;
+        profile.username = json.shop.name;
+        profile.profileUrl = json.shop.domain;
+        profile.emails = [
+          {
+            value: json.shop.email
+          }
+        ];
+        profile._raw = body;
+        profile._json = json;
+        done(null, profile);
+      } catch (error) {
+        e = error;
+        done(e);
+      }
+    });
+  };
 
+  Strategy.prototype.authenticate = function(req, options) {
+    _.defaults(options, {
+      authorizationURL: "https://" + options.shop + ".myshopify.com/admin/oauth/authorize",
+      tokenURL: "https://" + options.shop + ".myshopify.com/admin/oauth/access_token",
+      profileURL: "https://" + options.shop + ".myshopify.com/admin/shop.json"
+    });
+    return Strategy.__super__.authenticate.call(this, req, options);
+  };
 
-/*
- * Retrieve user profile from Shopify.
- *
- * This function constructs a normalized profile, with the following properties:
- *
- *   - `provider`         always set to `shopify`
- *   - `id`               the user's Shopify ID
- *   - `username`         the user's Shopify store name
- *   - `displayName`      the user's full name
- *   - `profileUrl`       the URL of the profile for the user on Shopify
- *   - `emails`           the user's email address, only returns emails[0]
- *
- * @param {String} accessToken
- * @param {Function} done
- * @api protected
- */
+  return Strategy;
 
-Strategy.prototype.userProfile = function(accessToken, done) {
-  this._oauth2.get(this._options.profileURL, accessToken, function(err, body, res) {
-    var e, error, json, profile;
-    if (err) {
-      return done(new InternalOAuthError('failed to fetch user profile', err));
-    }
-    try {
-      json = JSON.parse(body);
-      profile = {
-        provider: 'shopify'
-      };
-      profile.id = json.shop.id;
-      profile.displayName = json.shop.shop_owner;
-      profile.username = json.shop.name;
-      profile.profileUrl = json.shop.domain;
-      profile.emails = [
-        {
-          value: json.shop.email
-        }
-      ];
-      profile._raw = body;
-      profile._json = json;
-      done(null, profile);
-    } catch (error) {
-      e = error;
-      done(e);
-    }
-  });
-};
+})(OAuth2Strategy);
 
 
 /*

--- a/lib/passport-shopify/strategy.js
+++ b/lib/passport-shopify/strategy.js
@@ -1,18 +1,27 @@
-/**
+
+/*
  * Module dependencies.
  */
-var util = require('util')
-  , OAuth2Strategy = require('passport-oauth').OAuth2Strategy
-  , InternalOAuthError = require('passport-oauth').InternalOAuthError
-  , _ = require('underscore')
+var InternalOAuthError, OAuth2Strategy, Strategy, _, util;
 
-function Strategy(options, verify) {
+util = require('util');
 
-  options = options || {}
+OAuth2Strategy = require('passport-oauth').OAuth2Strategy;
 
-  if (typeof options.shop === 'undefined')
-    throw new TypeError('shop option is required!')
+InternalOAuthError = require('passport-oauth').InternalOAuthError;
 
+_ = require('lodash');
+
+
+/*
+ * Inherit from `OAuth2Strategy`.
+ */
+
+Strategy = function(options, verify) {
+  options = options || {};
+  if (typeof options.shop === 'undefined') {
+    throw new TypeError('shop option is required!');
+  }
   _.defaults(options, {
     authorizationURL: 'https://' + options.shop + '.myshopify.com/admin/oauth/authorize',
     tokenURL: 'https://' + options.shop + '.myshopify.com/admin/oauth/access_token',
@@ -20,27 +29,22 @@ function Strategy(options, verify) {
     userAgent: 'passport-shopify',
     customHeaders: {},
     scopeSeparator: ','
-  })
+  });
   _.defaults(options.customHeaders, {
     'User-Agent': options.userAgent
-  })
+  });
+  OAuth2Strategy.call(this, options, verify);
+  this.name = 'shopify';
+  this._profileURL = options.profileURL;
+  this._clientID = options.clientID;
+  this._clientSecret = options.clientID;
+  this._callbackURL = options.callbackURL;
+};
 
-  OAuth2Strategy.call(this, options, verify)
-  this.name = 'shopify'
-
-  this._profileURL = options.profileURL
-  this._clientID = options.clientID
-  this._clientSecret = options.clientID
-  this._callbackURL = options.callbackURL
-}
-
-/**
- * Inherit from `OAuth2Strategy`.
- */
-util.inherits(Strategy, OAuth2Strategy)
+util.inherits(Strategy, OAuth2Strategy);
 
 
-/**
+/*
  * Retrieve user profile from Shopify.
  *
  * This function constructs a normalized profile, with the following properties:
@@ -56,33 +60,40 @@ util.inherits(Strategy, OAuth2Strategy)
  * @param {Function} done
  * @api protected
  */
+
 Strategy.prototype.userProfile = function(accessToken, done) {
-  this._oauth2.get(this._options.profileURL, accessToken, function (err, body, res) {
-    if (err)
-      return done(new InternalOAuthError('failed to fetch user profile', err))
+  this._oauth2.get(this._options.profileURL, accessToken, function(err, body, res) {
+    var e, error, json, profile;
+    if (err) {
+      return done(new InternalOAuthError('failed to fetch user profile', err));
+    }
     try {
-      var json = JSON.parse(body)
-      var profile = { provider: 'shopify' }
-      profile.id = json.shop.id
-      profile.displayName = json.shop.shop_owner
-      profile.username = json.shop.name
-      profile.profileUrl = json.shop.domain
+      json = JSON.parse(body);
+      profile = {
+        provider: 'shopify'
+      };
+      profile.id = json.shop.id;
+      profile.displayName = json.shop.shop_owner;
+      profile.username = json.shop.name;
+      profile.profileUrl = json.shop.domain;
       profile.emails = [
         {
           value: json.shop.email
         }
-      ]
-      profile._raw = body
-      profile._json = json
-      done(null, profile)
-    } catch(e) {
-      done(e)
+      ];
+      profile._raw = body;
+      profile._json = json;
+      done(null, profile);
+    } catch (error) {
+      e = error;
+      done(e);
     }
-  })
-}
+  });
+};
 
 
-/**
+/*
  * Expose `Strategy`.
  */
-module.exports = Strategy
+
+module.exports = Strategy;

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
   },
   "main": "./lib/passport-shopify",
   "dependencies": {
-    "pkginfo": "0.2.x",
+    "lodash": "^3.10.1",
     "passport-oauth": "git://github.com/danteata/passport-oauth.git",
-    "underscore": "*"
+    "pkginfo": "0.3.x"
   },
   "devDependencies": {
-    "vows": "0.6.x",
+    "vows": "0.8.x",
     "express": "*",
     "passport": "*"
   },
@@ -36,6 +36,10 @@
     {
       "name": "Nick Baugh",
       "email": "niftylettuce@gmail.com"
+    },
+    {
+      "name": "Igor Goltsov",
+      "email": "riversy@gmail.com"
     }
   ],
   "license": "MIT"

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,0 +1,14 @@
+###
+# Module dependencies.
+###
+Strategy = require './strategy'
+
+###
+# Framework version.
+###
+require('pkginfo') module, 'version'
+
+###
+# Expose constructors.
+###
+exports.Strategy = Strategy

--- a/src/strategy.coffee
+++ b/src/strategy.coffee
@@ -1,0 +1,80 @@
+###
+# Module dependencies.
+###
+util = require('util')
+OAuth2Strategy = require('passport-oauth').OAuth2Strategy
+InternalOAuthError = require('passport-oauth').InternalOAuthError
+_ = require('lodash')
+
+###
+# Inherit from `OAuth2Strategy`.
+###
+Strategy = (options, verify) ->
+  options = options or {}
+
+  if typeof options.shop is 'undefined'
+    throw new TypeError('shop option is required!')
+
+  _.defaults options,
+    authorizationURL: 'https://' + options.shop + '.myshopify.com/admin/oauth/authorize'
+    tokenURL: 'https://' + options.shop + '.myshopify.com/admin/oauth/access_token'
+    profileURL: 'https://' + options.shop + '.myshopify.com/admin/shop.json'
+    userAgent: 'passport-shopify'
+    customHeaders: {}
+    scopeSeparator: ','
+
+  _.defaults options.customHeaders, 'User-Agent': options.userAgent
+
+  OAuth2Strategy.call @, options, verify
+
+  @name = 'shopify'
+
+  @_profileURL = options.profileURL
+  @_clientID = options.clientID
+  @_clientSecret = options.clientID
+  @_callbackURL = options.callbackURL
+
+  return
+
+util.inherits Strategy, OAuth2Strategy
+
+###
+# Retrieve user profile from Shopify.
+#
+# This function constructs a normalized profile, with the following properties:
+#
+#   - `provider`         always set to `shopify`
+#   - `id`               the user's Shopify ID
+#   - `username`         the user's Shopify store name
+#   - `displayName`      the user's full name
+#   - `profileUrl`       the URL of the profile for the user on Shopify
+#   - `emails`           the user's email address, only returns emails[0]
+#
+# @param {String} accessToken
+# @param {Function} done
+# @api protected
+###
+Strategy::userProfile = (accessToken, done) ->
+  @_oauth2.get @_options.profileURL, accessToken, (err, body, res) ->
+    if err
+      return done(new InternalOAuthError('failed to fetch user profile', err))
+    try
+      json = JSON.parse(body)
+      profile = provider: 'shopify'
+      profile.id = json.shop.id
+      profile.displayName = json.shop.shop_owner
+      profile.username = json.shop.name
+      profile.profileUrl = json.shop.domain
+      profile.emails = [ { value: json.shop.email } ]
+      profile._raw = body
+      profile._json = json
+      done null, profile
+    catch e
+      done e
+    return
+  return
+
+###
+# Expose `Strategy`.
+###
+module.exports = Strategy

--- a/src/strategy.coffee
+++ b/src/strategy.coffee
@@ -6,6 +6,7 @@ OAuth2Strategy = require('passport-oauth').OAuth2Strategy
 InternalOAuthError = require('passport-oauth').InternalOAuthError
 _ = require('lodash')
 
+
 ###
 # Inherit from `OAuth2Strategy`.
 ###

--- a/src/strategy.coffee
+++ b/src/strategy.coffee
@@ -1,79 +1,80 @@
 ###
 # Module dependencies.
 ###
-util = require('util')
 OAuth2Strategy = require('passport-oauth').OAuth2Strategy
 InternalOAuthError = require('passport-oauth').InternalOAuthError
 _ = require('lodash')
 
-
 ###
-# Inherit from `OAuth2Strategy`.
+# Inherit `Strategy` from `OAuth2Strategy`.
 ###
-Strategy = (options, verify) ->
-  options = options or {}
+class Strategy extends OAuth2Strategy
 
-  if typeof options.shop is 'undefined'
-    throw new TypeError('shop option is required!')
+  constructor: (options, verify) ->
 
-  _.defaults options,
-    authorizationURL: 'https://' + options.shop + '.myshopify.com/admin/oauth/authorize'
-    tokenURL: 'https://' + options.shop + '.myshopify.com/admin/oauth/access_token'
-    profileURL: 'https://' + options.shop + '.myshopify.com/admin/shop.json'
-    userAgent: 'passport-shopify'
-    customHeaders: {}
-    scopeSeparator: ','
+    options = options or {}
 
-  _.defaults options.customHeaders, 'User-Agent': options.userAgent
+    if not options.shop?
+      options.shop = 'example'
 
-  OAuth2Strategy.call @, options, verify
 
-  @name = 'shopify'
+    _.defaults options,
+      authorizationURL: "https://#{options.shop}.myshopify.com/admin/oauth/authorize"
+      tokenURL: "https://#{options.shop}.myshopify.com/admin/oauth/access_token"
+      profileURL: "https://#{options.shop}.myshopify.com/admin/shop.json"
+      userAgent: 'passport-shopify'
+      customHeaders: {}
+      scopeSeparator: ','
 
-  @_profileURL = options.profileURL
-  @_clientID = options.clientID
-  @_clientSecret = options.clientID
-  @_callbackURL = options.callbackURL
 
-  return
+    _.defaults options.customHeaders,
+      'User-Agent': options.userAgent
 
-util.inherits Strategy, OAuth2Strategy
+    super(options, verify)
 
-###
-# Retrieve user profile from Shopify.
-#
-# This function constructs a normalized profile, with the following properties:
-#
-#   - `provider`         always set to `shopify`
-#   - `id`               the user's Shopify ID
-#   - `username`         the user's Shopify store name
-#   - `displayName`      the user's full name
-#   - `profileUrl`       the URL of the profile for the user on Shopify
-#   - `emails`           the user's email address, only returns emails[0]
-#
-# @param {String} accessToken
-# @param {Function} done
-# @api protected
-###
-Strategy::userProfile = (accessToken, done) ->
-  @_oauth2.get @_options.profileURL, accessToken, (err, body, res) ->
-    if err
-      return done(new InternalOAuthError('failed to fetch user profile', err))
-    try
-      json = JSON.parse(body)
-      profile = provider: 'shopify'
-      profile.id = json.shop.id
-      profile.displayName = json.shop.shop_owner
-      profile.username = json.shop.name
-      profile.profileUrl = json.shop.domain
-      profile.emails = [ { value: json.shop.email } ]
-      profile._raw = body
-      profile._json = json
-      done null, profile
-    catch e
-      done e
+    @name = 'shopify'
+
+    @_profileURL = options.profileURL
+    @_clientID = options.clientID
+    @_clientSecret = options.clientID
+    @_callbackURL = options.callbackURL
+
     return
-  return
+
+  userProfile: (accessToken, done) ->
+
+    @_oauth2.get @_options.profileURL, accessToken, (err, body, res) ->
+
+      if err
+        return done(new InternalOAuthError('Failed to fetch user profile', err))
+      try
+        json = JSON.parse(body)
+        profile = provider: 'shopify'
+        profile.id = json.shop.id
+        profile.displayName = json.shop.shop_owner
+        profile.username = json.shop.name
+        profile.profileUrl = json.shop.domain
+        profile.emails = [ { value: json.shop.email } ]
+        profile._raw = body
+        profile._json = json
+        done null, profile
+      catch e
+        done e
+      return
+
+    return
+
+
+  authenticate: (req, options) ->
+
+    _.defaults options,
+      authorizationURL: "https://" + options.shop + ".myshopify.com/admin/oauth/authorize",
+      tokenURL: "https://" + options.shop + ".myshopify.com/admin/oauth/access_token",
+      profileURL: "https://" + options.shop + ".myshopify.com/admin/shop.json",
+
+    super(req, options)
+
+
 
 ###
 # Expose `Strategy`.

--- a/src/strategy.coffee
+++ b/src/strategy.coffee
@@ -17,15 +17,15 @@ class Strategy extends OAuth2Strategy
     if not options.shop?
       options.shop = 'example'
 
+    shopName = @normalizeShopName options.shop
 
     _.defaults options,
-      authorizationURL: "https://#{options.shop}.myshopify.com/admin/oauth/authorize"
-      tokenURL: "https://#{options.shop}.myshopify.com/admin/oauth/access_token"
-      profileURL: "https://#{options.shop}.myshopify.com/admin/shop.json"
+      authorizationURL: "https://#{shopName}/admin/oauth/authorize"
+      tokenURL: "https://#{shopName}/admin/oauth/access_token"
+      profileURL: "https://#{shopName}/admin/shop.json"
       userAgent: 'passport-shopify'
       customHeaders: {}
       scopeSeparator: ','
-
 
     _.defaults options.customHeaders,
       'User-Agent': options.userAgent
@@ -67,12 +67,26 @@ class Strategy extends OAuth2Strategy
 
   authenticate: (req, options) ->
 
-    _.defaults options,
-      authorizationURL: "https://" + options.shop + ".myshopify.com/admin/oauth/authorize",
-      tokenURL: "https://" + options.shop + ".myshopify.com/admin/oauth/access_token",
-      profileURL: "https://" + options.shop + ".myshopify.com/admin/shop.json",
+    # If shop is defined
+    # with authentication
+    if options.shop?
 
+      shopName = @normalizeShopName options.shop
+
+      _.defaults options,
+        authorizationURL: "https://#{shopName}/admin/oauth/authorize",
+        tokenURL: "https://#{shopName}/admin/oauth/access_token",
+        profileURL: "https://#{shopName}/admin/shop.json",
+
+    # Call superclass
     super(req, options)
+
+  normalizeShopName: (shop) ->
+
+    if shop.match /^[a-z0-9-_]+$/i
+      "#{shop}.myshopify.com"
+    else
+      shop
 
 
 


### PR DESCRIPTION
Thank you for your library.
There was a trouble with usage of previous implementation of this strategy with multi-threads. It caused because we were forced to register new strategy instance for each shop. But I've quite rewritten that. It's possible now to use the implementation without 'shop' parameter when we register strategy. So we may use one strategy instance for many stores in this version. 
I've also translated the module to CoffeeScript but didn't modified tests. It looks like they are outdated. unfortunately, have no time to create new. We use this lib in our project so it should work. 