### PR TITLE
restore original passport-oauth

### DIFF
--- a/lib/passport-shopify/strategy.js
+++ b/lib/passport-shopify/strategy.js
@@ -42,7 +42,7 @@ Strategy = (function(superClass) {
     this.name = 'shopify';
     this._profileURL = options.profileURL;
     this._clientID = options.clientID;
-    this._clientSecret = options.clientID;
+    this._clientSecret = options.clientSecret;
     this._callbackURL = options.callbackURL;
     return;
   }

--- a/lib/passport-shopify/strategy.js
+++ b/lib/passport-shopify/strategy.js
@@ -48,7 +48,7 @@ Strategy = (function(superClass) {
   }
 
   Strategy.prototype.userProfile = function(accessToken, done) {
-    this._oauth2.get(this._options.profileURL, accessToken, function(err, body, res) {
+    this._oauth2.get(this._profileURL, accessToken, function(err, body, res) {
       var e, error, json, profile;
       if (err) {
         return done(new InternalOAuthError('Failed to fetch user profile', err));
@@ -81,11 +81,11 @@ Strategy = (function(superClass) {
     var shopName;
     if (options.shop != null) {
       shopName = this.normalizeShopName(options.shop);
-      _.defaults(options, {
-        authorizationURL: "https://" + shopName + "/admin/oauth/authorize",
-        tokenURL: "https://" + shopName + "/admin/oauth/access_token",
-        profileURL: "https://" + shopName + "/admin/shop.json"
-      });
+
+      // update _oauth2 settings
+      this._oauth2._authorizeUrl = "https://" + shopName + "/admin/oauth/authorize";
+      this._oauth2._accessTokenUrl = "https://" + shopName + "/admin/oauth/access_token";
+      this._profileURL = "https://" + shopName + "/admin/shop.json";
     }
     return Strategy.__super__.authenticate.call(this, req, options);
   };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "./lib/passport-shopify",
   "dependencies": {
     "lodash": "^3.10.1",
-    "passport-oauth": "git://github.com/danteata/passport-oauth.git",
+    "passport-oauth": "1.x.x",
     "pkginfo": "0.3.x"
   },
   "devDependencies": {

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -79,8 +79,8 @@ vows.describe('ShopifyStrategy').addBatch({
 
       // mock
       strategy._oauth2.get = function(url, accessToken, callback) {
-        if (url == 'https://api.shopify.com/user') {
-          var body = '{ "login": "octocat", "id": 1, "name": "monalisa octocat", "email": "octocat@shopify.com", "html_url": "https://shopify.com/octocat" }';
+        if (url == 'https://example.myshopify.com/admin/shop.json') {
+          var body = '{ "shop": { "name": "octocat", "id": 1, "shop_owner": "monalisa octocat", "email": "octocat@shopify.com", "domain": "https://shopify.com/octocat" } }';
           callback(null, body, undefined);
         } else {
           callback(new Error('Incorrect user profile URL'));
@@ -128,14 +128,14 @@ vows.describe('ShopifyStrategy').addBatch({
       var strategy = new ShopifyStrategy({
         clientID: 'ABC123',
         clientSecret: 'secret',
-        userProfileURL: 'https://shopify.corpDomain/api/v3/user',
+        profileURL: 'https://shopify.corpDomain/api/v3/user',
       },
       function() {});
 
       // mock
       strategy._oauth2.get = function(url, accessToken, callback) {
         if (url == 'https://shopify.corpDomain/api/v3/user') {
-          var body = '{ "login": "octocat", "id": 1, "name": "monalisa octocat", "email": "octocat@shopify.com", "html_url": "https://shopify.com/octocat" }';
+          var body = '{ "shop": { "name": "octocat", "id": 1, "shop_owner": "monalisa octocat", "email": "octocat@shopify.com", "domain": "https://shopify.com/octocat" } }';
           callback(null, body, undefined);
         } else {
           callback(new Error('Incorrect user profile URL'));


### PR DESCRIPTION
it’s not necessary to move “_oauth2” initialization to the `authenticate` method, you can just update his settings (`_oauth2._authorizeUrl` and `_oauth2._accessTokenUrl`) from there

Also I fixed broken tests and included other minor fixes.